### PR TITLE
Predict on new addresses

### DIFF
--- a/lead/model/address.py
+++ b/lead/model/address.py
@@ -21,6 +21,7 @@ join input.community_areas c
     on st_intersects(b.geom, c.geom)
 join input.wards w
     on st_intersects(b.geom, w.geom) and st_intersects(c.geom, w.geom)
+group by 1,2,3,4
 )
 select
     null address,

--- a/lead/model/data.py
+++ b/lead/model/data.py
@@ -84,7 +84,7 @@ class LeadData(Step):
         """
         if self.address:
             index_columns = ['address', 'census_block_id', 'ward_id', 'community_area_id', 'date']
-            left_columns = ['ward_id', 'address_lat', 'address_lng']
+            left_columns = ['address_lat', 'address_lng']
         if not self.address:
             index_columns = ['kid_id', 'address_id', 'date']
             left_columns = ['ward_id', 'community_area_id', 'address_lat', 'address_lng']

--- a/lead/model/data.py
+++ b/lead/model/data.py
@@ -83,7 +83,7 @@ class LeadData(Step):
                 sample weights, and evaluation.
         """
         if self.address:
-            index_columns = ['address', 'census_block_id', 'census_tract_id', 'community_area_id', 'date']
+            index_columns = ['address', 'census_block_id', 'ward_id', 'community_area_id', 'date']
             left_columns = ['ward_id', 'address_lat', 'address_lng']
         if not self.address:
             index_columns = ['kid_id', 'address_id', 'date']

--- a/lead/model/data.py
+++ b/lead/model/data.py
@@ -83,7 +83,7 @@ class LeadData(Step):
                 sample weights, and evaluation.
         """
         if self.address:
-            index_columns = ['address','date']
+            index_columns = ['address', 'census_block_id', 'ward_id', 'community_area_id', 'date']
         if not self.address:
             index_columns = ['kid_id', 'address_id', 'date']
 

--- a/lead/model/data.py
+++ b/lead/model/data.py
@@ -32,8 +32,8 @@ class LeadData(Step):
             year_max: the year to stop generating features
             wic_lag: a lag for the WIC aggregations, parsed by
                 drain.data.parse_delta, e.g. '6m' is a six month lag.
-                Defaultis to None, which is no lag.
-            dtype: the dtype to use for features. Defaults to np.float16.
+                Default is to None, which is no lag.
+            dtype: the dtype to use for features. Defaults to np.float16 for memory efficiency.
             address: whether to build an address dataset. Defaults to False,
                 which builds a kid dataset.
         """
@@ -83,15 +83,16 @@ class LeadData(Step):
                 sample weights, and evaluation.
         """
         if self.address:
-            index_columns = ['address', 'census_block_id', 'ward_id', 'community_area_id', 'date']
+            index_columns = ['address', 'census_block_id', 'census_tract_id', 'community_area_id', 'date']
+            left_columns = ['ward_id', 'address_lat', 'address_lng']
         if not self.address:
             index_columns = ['kid_id', 'address_id', 'date']
+            left_columns = ['ward_id', 'community_area_id', 'address_lat', 'address_lng']
 
-        left_columns = ['ward_id', 'community_area_id', 'address_lat', 'address_lng']
         left = left[index_columns + left_columns]
 
         logging.info('Binarizing community area and ward')
-        left = data.binarize(left, ['community_area_id', 'ward_id'], astype=self.dtype)
+        left = data.binarize(left, ['community_area_id', 'ward_id'], astype=self.dtype, drop=(not self.address))
 
         logging.info('Joining aggregations')
         X = left.join([a.result for a in self.aggregation_joins] + [acs])

--- a/lead/model/experiments.py
+++ b/lead/model/experiments.py
@@ -1,6 +1,13 @@
 from .workflows import *
 from copy import deepcopy
 
+def bll6_forest_where():
+    """
+    The basic temporal cross-validation workflow
+    """
+    return bll6_models(forest(), transform_search={'outcome_where_expr':[None, 'max_bll0 == max_bll0']})
+    return bll6_models(forest(), transform_search={'outcome_where_expr':['max_bll0 == max_bll0']})
+
 def bll6_forest_no_wic():
     """
     No wic features

--- a/lead/model/experiments.py
+++ b/lead/model/experiments.py
@@ -1,13 +1,6 @@
 from .workflows import *
 from copy import deepcopy
 
-def bll6_forest_where():
-    """
-    The basic temporal cross-validation workflow
-    """
-    return bll6_models(forest(), transform_search={'outcome_where_expr':[None, 'max_bll0 == max_bll0']})
-    return bll6_models(forest(), transform_search={'outcome_where_expr':['max_bll0 == max_bll0']})
-
 def bll6_forest_no_wic():
     """
     No wic features

--- a/lead/model/transform.py
+++ b/lead/model/transform.py
@@ -14,19 +14,23 @@ class LeadTransform(Step):
     performing feature selection and creating sample weights.
     """
     def __init__(self, inputs, outcome_expr, aggregations,
-            wic_sample_weight=0, exclude=[], include=[]):
+            outcome_where_expr=None, wic_sample_weight=0,
+            exclude=[], include=[]):
         """
         Args:
             inputs: list containing a LeadCrossValidate step
             outcome_expr: the query to perform on the auxillary information to produce an outcome variable
             aggregations: defines which of the SpacetimeAggregations to include
-            and which to drop
+                and which to drop
+            outcome_where_expr: where to evaluate the outcome_expr,
+                defaults to None, which means everywhere
             wic_sample_weight: optional different sample weight for wic kids
         """
         Step.__init__(self,
                 inputs=inputs,
                 outcome_expr=outcome_expr,
                 aggregations=aggregations,
+                outcome_where_expr=outcome_where_expr,
                 wic_sample_weight=wic_sample_weight, 
                 exclude=exclude, include=include)
 
@@ -40,6 +44,8 @@ class LeadTransform(Step):
 
         """
         y = aux.eval(self.outcome_expr)
+        if self.outcome_where_expr is not None:
+            y = y.where(aux.eval(self.outcome_where_expr))
 
         logging.info('Selecting aggregations')
         aggregations = self.get_input(LeadData).aggregations

--- a/lead/model/workflows.py
+++ b/lead/model/workflows.py
@@ -143,7 +143,8 @@ def bll6_models(estimators, cv_search={}, transform_search={}):
     transformd = dict(
         wic_sample_weight=[0],
         aggregations=aggregations.args,
-        outcome_expr=['max_bll0 >= 6']
+        outcome_expr='max_bll0 >= 6',
+        outcome_where_expr='max_bll0 == max_bll0' # this means max_bll0.notnull()
     )
     transformd.update(transform_search)
     return models(estimators, cvd, transformd)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-drain
+git+https://github.com/potash/drain
 git+https://github.com/potash/scikit-learn@merged/balanced-random-forest#egg=scikit-learn


### PR DESCRIPTION
This updates the saved feature matrix ("address_data_today") to include a row for a new address in each geography tuple (intersection of a community area, ward, and census block-- there are ~60k such tuples). This gets used by the API whenever we get an address that geocodes but was not in any of our address datasets, we simply grab the row corresponding to its geography tuple.