### PR TITLE
v1.0.0-rc.1

### DIFF
--- a/lead/features/wic.py
+++ b/lead/features/wic.py
@@ -46,7 +46,7 @@ class EnrollAggregation(SpacetimeAggregation):
                 parallel=parallel)
 
     def get_aggregates(self, date, delta):
-        enroll = self.inputs[0].get_result()
+        enroll = self.inputs[0].result
         aggregates = [
             Aggregate('medical_risk', 'any', fname=False),
             Aggregate(['household_size', 'household_income'], 
@@ -89,7 +89,7 @@ class BirthAggregation(SpacetimeAggregation):
                 parallel=parallel)
 
     def get_aggregates(self, date, delta):
-        births = self.inputs[0].get_result()
+        births = self.inputs[0].result
         aggregates = [
             Aggregate('length', 'max', fname=False),
             Aggregate('weight', 'max', fname=False),
@@ -125,7 +125,7 @@ class PrenatalAggregation(SpacetimeAggregation):
                 parallel=parallel)
 
     def get_aggregates(self, date, delta):
-        prenatal = self.inputs[0].get_result()
+        prenatal = self.inputs[0].result
 
         aggregates = [
             Count(),

--- a/lead/model/address.py
+++ b/lead/model/address.py
@@ -6,7 +6,38 @@ import pandas as pd
 import numpy as np
 import logging
 
-addresses = FromSQL(table='output.addresses')
+# in addition to all addresses, we add all cells in the partition
+# created by intersecting blocks, wards and communities 
+# in anticipation of any new addresses in deployment
+addresses = FromSQL("""
+with blocks as (
+select
+    b.geoid10::double precision census_block_id,
+    substring(b.geoid10 for 11)::double precision census_tract_id,
+    c.area_numbe::int community_area_id,
+    w.ward::int ward_id
+from input.census_blocks b
+join input.community_areas c
+    on st_intersects(b.geom, c.geom)
+join input.wards w
+    on st_intersects(b.geom, w.geom) and st_intersects(c.geom, w.geom)
+group by 1,2,3,4
+)
+select
+    null address,
+    null address_lat,
+    null address_lng,
+    null as address_id,
+    null as building_id,
+    null as complex_id, *
+from blocks
+UNION ALL
+select address, address_lat, address_lng, 
+    address_id, building_id, complex_id,
+    census_block_id, census_tract_id, 
+    community_area_id, ward_id
+from output.addresses
+    """, tables=['output.addresses', 'input.census_blocks', 'input.census_tracts', 'input.community_areas', 'input.wards'])
 addresses.target = True
 
 class LeadAddressLeft(Step):

--- a/lead/model/data.py
+++ b/lead/model/data.py
@@ -32,8 +32,8 @@ class LeadData(Step):
             year_max: the year to stop generating features
             wic_lag: a lag for the WIC aggregations, parsed by
                 drain.data.parse_delta, e.g. '6m' is a six month lag.
-                Defaultis to None, which is no lag.
-            dtype: the dtype to use for features. Defaults to np.float16.
+                Default is to None, which is no lag.
+            dtype: the dtype to use for features. Defaults to np.float16 for memory efficiency.
             address: whether to build an address dataset. Defaults to False,
                 which builds a kid dataset.
         """
@@ -83,15 +83,16 @@ class LeadData(Step):
                 sample weights, and evaluation.
         """
         if self.address:
-            index_columns = ['address','date']
+            index_columns = ['address', 'census_block_id', 'ward_id', 'community_area_id', 'date']
+            left_columns = ['address_lat', 'address_lng']
         if not self.address:
             index_columns = ['kid_id', 'address_id', 'date']
+            left_columns = ['ward_id', 'community_area_id', 'address_lat', 'address_lng']
 
-        left_columns = ['ward_id', 'community_area_id', 'address_lat', 'address_lng']
         left = left[index_columns + left_columns]
 
         logging.info('Binarizing community area and ward')
-        left = data.binarize(left, ['community_area_id', 'ward_id'], astype=self.dtype)
+        left = data.binarize(left, ['community_area_id', 'ward_id'], astype=self.dtype, drop=(not self.address))
 
         logging.info('Joining aggregations')
         X = left.join([a.result for a in self.aggregation_joins] + [acs])

--- a/lead/model/data.py
+++ b/lead/model/data.py
@@ -94,7 +94,7 @@ class LeadData(Step):
         left = data.binarize(left, ['community_area_id', 'ward_id'], astype=self.dtype)
 
         logging.info('Joining aggregations')
-        X = left.join([a.get_result() for a in self.aggregation_joins] + [acs])
+        X = left.join([a.result for a in self.aggregation_joins] + [acs])
         # delete all aggregation inputs so that memory can be freed
         for a in self.aggregation_joins: del a._result
 

--- a/lead/model/data.py
+++ b/lead/model/data.py
@@ -96,7 +96,7 @@ class LeadData(Step):
         logging.info('Joining aggregations')
         X = left.join([a.result for a in self.aggregation_joins] + [acs])
         # delete all aggregation inputs so that memory can be freed
-        for a in self.aggregation_joins: del a._result
+        for a in self.aggregation_joins: del a.result
 
         if not self.address:
             logging.info('Adding auxillary features')

--- a/lead/model/transform.py
+++ b/lead/model/transform.py
@@ -14,19 +14,23 @@ class LeadTransform(Step):
     performing feature selection and creating sample weights.
     """
     def __init__(self, inputs, outcome_expr, aggregations,
-            wic_sample_weight=0, exclude=[], include=[]):
+            outcome_where_expr=None, wic_sample_weight=0,
+            exclude=[], include=[]):
         """
         Args:
             inputs: list containing a LeadCrossValidate step
             outcome_expr: the query to perform on the auxillary information to produce an outcome variable
             aggregations: defines which of the SpacetimeAggregations to include
-            and which to drop
+                and which to drop
+            outcome_where_expr: where to evaluate the outcome_expr,
+                defaults to None, which means everywhere
             wic_sample_weight: optional different sample weight for wic kids
         """
         Step.__init__(self,
                 inputs=inputs,
                 outcome_expr=outcome_expr,
                 aggregations=aggregations,
+                outcome_where_expr=outcome_where_expr,
                 wic_sample_weight=wic_sample_weight, 
                 exclude=exclude, include=include)
 
@@ -40,6 +44,8 @@ class LeadTransform(Step):
 
         """
         y = aux.eval(self.outcome_expr)
+        if self.outcome_where_expr is not None:
+            y = y.where(aux.eval(self.outcome_where_expr))
 
         logging.info('Selecting aggregations')
         aggregations = self.get_input(LeadData).aggregations

--- a/lead/model/workflows.py
+++ b/lead/model/workflows.py
@@ -143,7 +143,8 @@ def bll6_models(estimators, cv_search={}, transform_search={}):
     transformd = dict(
         wic_sample_weight=[0],
         aggregations=aggregations.args,
-        outcome_expr=['max_bll0 >= 6']
+        outcome_expr='max_bll0 >= 6',
+        outcome_where_expr='max_bll0 == max_bll0' # this means max_bll0.notnull()
     )
     transformd.update(transform_search)
     return models(estimators, cvd, transformd)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-drain
+git+https://github.com/potash/drain
 git+https://github.com/potash/scikit-learn@merged/balanced-random-forest#egg=scikit-learn


### PR DESCRIPTION
Testing has been completed on this commit alongside the development version of the v0.5.0 of the API on the development server. @geneorama, please confirm this by approving this pull request.

This resolves #5 and [lead-prediction-runner#24](https://gitlab.cityofchicago.org/lead-paint-research/lead-API-internal/issues/24). @potash, please confirm accuracy of which issues it closes by approving this pull request.

This will start establishing versioning for this project. ~~I propose v0.9.0. The model is likely to change to [support v0.6.0 of the API](https://github.com/Chicago/lead-safe-api-docs/wiki#roadmap) (e.g., defining how we label the risk score). After this pull request is accepted, we will create a GitHub release and tagging this as `v0.9.0`.~~ _See thread._
  