### PR TITLE
fix max year

### DIFF
--- a/lead/model/cv.py
+++ b/lead/model/cv.py
@@ -7,12 +7,13 @@ from lead.model.data import LeadData
 from datetime import date
 import pandas as pd
 import numpy as np
+import os
 import logging
 from drain.util import lru_cache
 
 
 YEAR_MIN = 2003
-YEAR_MAX = 2017
+YEAR_MAX = pd.Timestamp(os.environ['TODAY']).year
 
 @lru_cache(maxsize=10)
 def lead_data(month, day, wic_lag):

--- a/lead/model/workflows.py
+++ b/lead/model/workflows.py
@@ -93,7 +93,7 @@ def bll6_models(estimators, cv_search={}, transform_search={}, dump_estimator=Fa
 
     """
     cvd = dict(
-        year=range(2013, 2014+1),
+        year=range(2011, 2014+1),
         month=1,
         day=1,
         train_years=[6],


### PR DESCRIPTION
Instead of hardcoding the `MAX_YEAR` for data generation, detect it from the `TODAY` environment variable.